### PR TITLE
Simplify characters handling logic

### DIFF
--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ReadOnlyInstanceProperty.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ReadOnlyInstanceProperty.java
@@ -26,7 +26,6 @@ import io.micronaut.inject.ast.PropertyElement;
 public class ReadOnlyInstanceProperty extends LoadableFXMLElement<LoadableFXMLElement<?>> {
 
     private final PropertyElement propertyElement;
-    private String value;
 
     public ReadOnlyInstanceProperty(LoadableFXMLElement<?> parent, PropertyElement propertyElement) {
         super(parent);
@@ -40,16 +39,7 @@ public class ReadOnlyInstanceProperty extends LoadableFXMLElement<LoadableFXMLEl
 
     @Override
     public void handleCharacters(CompilerContext context, String text) {
-        value = MULTI_WHITESPACE_PATTERN.matcher(text).replaceAll(" ").trim();
-    }
-
-    @Override
-    public void handleEndElement(CompilerContext context) {
-        super.handleEndElement(context);
-
-        if (value == null || value.isEmpty()) {
-            return;
-        }
+        String value = MULTI_WHITESPACE_PATTERN.matcher(text).replaceAll(" ").trim();
 
         getParent().apply(context, this, LoadableFXMLElement.loadString(context, value));
     }

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ReadWriteInstanceProperty.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ReadWriteInstanceProperty.java
@@ -21,7 +21,6 @@ import io.micronaut.inject.ast.PropertyElement;
 public class ReadWriteInstanceProperty extends FXMLElement<LoadableFXMLElement<?>> {
 
     private final PropertyElement propertyElement;
-    private String value;
 
     public ReadWriteInstanceProperty(LoadableFXMLElement<?> parent, PropertyElement propertyElement) {
         super(parent);
@@ -41,14 +40,7 @@ public class ReadWriteInstanceProperty extends FXMLElement<LoadableFXMLElement<?
 
     @Override
     public void handleCharacters(CompilerContext context, String text) {
-        value = MULTI_WHITESPACE_PATTERN.matcher(text).replaceAll(" ").trim();
-    }
-
-    @Override
-    public void handleEndElement(CompilerContext context) {
-        if (value == null || value.isEmpty()) {
-            return;
-        }
+        String value = MULTI_WHITESPACE_PATTERN.matcher(text).replaceAll(" ").trim();
 
         getParent().apply(context, this, LoadableFXMLElement.loadString(context, value));
     }

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/StaticPropertyFXMLElement.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/StaticPropertyFXMLElement.java
@@ -24,7 +24,6 @@ public class StaticPropertyFXMLElement extends FXMLElement<LoadableFXMLElement<?
 
     private final String name;
     private final ClassElement staticClassElement;
-    private String value;
 
     public StaticPropertyFXMLElement(LoadableFXMLElement<?> parent, String name, ClassElement classElement) {
         super(parent);
@@ -40,11 +39,8 @@ public class StaticPropertyFXMLElement extends FXMLElement<LoadableFXMLElement<?
 
     @Override
     public void handleCharacters(CompilerContext context, String text) {
-        value = MULTI_WHITESPACE_PATTERN.matcher(text).replaceAll(" ").trim();
-    }
+        String value = MULTI_WHITESPACE_PATTERN.matcher(text).replaceAll(" ").trim();
 
-    @Override
-    public void handleEndElement(CompilerContext context) {
         getParent().apply(
                 context,
                 staticClassElement,


### PR DESCRIPTION
Apply characters to parent element immediately, instead of caching them and applying only on element handling end.

Task-number: #8