### PR TITLE
Fix handling of primitive elements that take two variable slots

### DIFF
--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/CompilerContext.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/CompilerContext.java
@@ -64,7 +64,7 @@ public interface CompilerContext extends BindingContext {
 
     int getDefaultSlot();
 
-    int acquireSlot();
+    int acquireSlot(ClassElement classElement);
 
     void releaseSlot(int slot);
 }

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/CopyFXMLElement.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/CopyFXMLElement.java
@@ -46,6 +46,7 @@ public class CopyFXMLElement extends IdentifiableFXMLElement {
             }
 
             this.continuation = continuation;
+            acquireSlot(context);
 
             return;
         }

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/IdentifiableFXMLElement.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/IdentifiableFXMLElement.java
@@ -30,16 +30,11 @@ import java.util.Map;
 // FXML element that can be identified. Can have id assigned, so, can be referenced anywhere in FXML file.
 abstract class IdentifiableFXMLElement extends LoadableFXMLElement<FXMLElement<?>> {
 
-    private int slot;
+    private int slot = -1;
     private boolean hasId;
 
     IdentifiableFXMLElement(FXMLElement<?> parent) {
         super(parent);
-    }
-
-    @Override
-    public void initialize(CompilerContext context) {
-        slot = context.acquireSlot();
     }
 
     @Override
@@ -175,7 +170,7 @@ abstract class IdentifiableFXMLElement extends LoadableFXMLElement<FXMLElement<?
             parent.apply(context, this);
         }
 
-        if (!hasId) {
+        if (slot != -1 && !hasId) {
             context.releaseSlot(slot);
         }
     }
@@ -199,5 +194,9 @@ abstract class IdentifiableFXMLElement extends LoadableFXMLElement<FXMLElement<?
                 );
 
         applyInstanceProperty(context, classElement, propertyElement, loadString(context, value));
+    }
+
+    void acquireSlot(CompilerContext context) {
+        slot = context.acquireSlot(getClassElement());
     }
 }

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/IncludeFXMLElement.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/IncludeFXMLElement.java
@@ -46,13 +46,6 @@ public class IncludeFXMLElement extends IdentifiableFXMLElement {
     }
 
     @Override
-    public void initialize(CompilerContext context) {
-        super.initialize(context);
-
-        this.charset = context.getCharset();
-    }
-
-    @Override
     public boolean requiresAttributesLookahead() {
         // NB: We use attributes lookahead here, as actual element type can only be determined from attribute.
         return true;
@@ -108,7 +101,8 @@ public class IncludeFXMLElement extends IdentifiableFXMLElement {
         CompileTask compileTask = context.getCompileTask(location)
                 .orElseThrow(() -> context.compileError("Source file " + location + " not found."));
 
-        reference = compileTask.compile(charset);
+        reference = compileTask.compile(charset != null ? charset : context.getCharset());
+        acquireSlot(context);
 
         ExpressionContext.Loadable controllerAccessorFactory = context.getControllerAccessorFactory();
 

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/InstanceDeclarationFXMLElement.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/InstanceDeclarationFXMLElement.java
@@ -717,6 +717,8 @@ public class InstanceDeclarationFXMLElement extends IdentifiableFXMLElement {
 
     @Override
     public void handleAttributesLookaheadFinish(CompilerContext context) {
+        acquireSlot(context);
+
         if (constructCommand != null) {
             context.getRenderer().render(constructCommand);
             constructCommand = null;

--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ReferenceFXMLElement.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ReferenceFXMLElement.java
@@ -43,6 +43,7 @@ public class ReferenceFXMLElement extends IdentifiableFXMLElement {
             }
 
             this.continuation = continuation;
+            acquireSlot(context);
 
             return;
         }

--- a/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive/TwoSlotsPrimitive.java
+++ b/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive/TwoSlotsPrimitive.java
@@ -13,15 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.paullo612.mlfx.compiler.test;
+package io.github.paullo612.mlfx.compiler.compliance.two_slots_primitive;
 
-public class FooFactory {
+import io.github.paullo612.mlfx.api.CompileFXML;
 
-    public static int foo() {
-        return 42;
-    }
-
-    public static long bar() {
-        return 42L;
-    }
-}
+@CompileFXML(fxmlDirectories = "io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive")
+class TwoSlotsPrimitive { }

--- a/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive/twoSlotsPrimitive.fxml
+++ b/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive/twoSlotsPrimitive.fxml
@@ -1,0 +1,34 @@
+<!--
+  Copyright 2023 Paullo612
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?import io.github.paullo612.mlfx.compiler.test.Crankshaft?>
+<?import io.github.paullo612.mlfx.compiler.test.Crankpin?>
+<?import io.github.paullo612.mlfx.compiler.test.FooFactory?>
+
+<Crankshaft xmlns="http://javafx.com/javafx/19.0.0" xmlns:fx="http://javafx.com/fxml/1">
+    <fx:define>
+        <!-- Save primitive that takes two slots -->
+        <FooFactory fx:id="pinId" fx:factory="bar"/>
+        <!-- Save reference that takes one slot after -->
+        <Crankpin fx:id="firstPin" id="1"/>
+    </fx:define>
+    <crankpins>
+        <!--
+        And let it all crash with VerifyError if we're handling primitives that take two variable slots incorrectly
+        -->
+        <fx:reference source="firstPin"/>
+        <Crankpin id="$pinId"/>
+    </crankpins>
+</Crankshaft>


### PR DESCRIPTION
Do not acquire variable slot on element initialization. Acquire slot manually, when element's type is known and will never change.

Task-number: #14