### PR TITLE
Simplify CompiledFXMLLoader's getURI method logic

### DIFF
--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/RootRenderer.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/RootRenderer.java
@@ -367,38 +367,20 @@ class RootRenderer implements CompilerContext.Renderer {
 
         getURIMethod.visitCode();
 
-        // URL resource = getClass().getResource(classFileName);
-        // if (resource == null) {
-        //     throw new CompiledLoadException(exceptionMessage);
-        // }
-        // try {
-        //     return resource.toURI();
-        // } catch (URISyntaxException e) {
-        //     throw new CompiledLoadException(e);
-        // }
-
-        Type urlType = Type.getType(URL.class);
-
-        Label start = getURIMethod.mark();
-
-        getURIMethod.newInstance(urlType);
-        getURIMethod.dup();
-
-        // Expands to
         // URL resource = getClass().getResource(fxmlFileName);
         // if (resource == null) {
         //     throw new CompiledLoadException(exceptionMessage);
         // }
         loadLocation(fxmlFileName, getURIMethod);
 
-        getURIMethod.push(fxmlFileName);
+        // try {
+        //     return resource.toURI();
+        // } catch (URISyntaxException e) {
+        //     throw new CompiledLoadException(e);
+        // }
+        Label start = getURIMethod.mark();
 
-        getURIMethod.invokeConstructor(
-                urlType,
-                new Method(RenderUtils.CONSTRUCTOR_N, "(" + urlType.getDescriptor() + RenderUtils.STRING_D + ")V")
-        );
-
-        getURIMethod.invokeVirtual(urlType, new Method("toURI", "()" + uriType.getDescriptor()));
+        getURIMethod.invokeVirtual(Type.getType(URL.class), new Method("toURI", "()" + uriType.getDescriptor()));
         getURIMethod.returnValue();
 
         Label end = getURIMethod.mark();


### PR DESCRIPTION
Do not create extra URL object which points to same location.

Task-number: #16