### PR TITLE
Reduce runtime dependency set

### DIFF
--- a/api/micronaut/pom.xml
+++ b/api/micronaut/pom.xml
@@ -26,6 +26,16 @@
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-inject</artifactId>
             <version>${micronaut.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
snakeyaml is definitely not needed at runtime to do a simple BeanIntrospection based DI. Looks like javax.annotation-api is also not nneded.

Task-number: #27