### PR TITLE
Fix handling of binding expressions that return two slot primitives

### DIFF
--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/expression/BindingImpl.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/expression/BindingImpl.java
@@ -69,11 +69,12 @@ class BindingImpl extends StaticBindingImpl<BindingContext> {
                 ClassElement targetType) {
             expressionRenderer.render(methodVisitor -> {
                 methodVisitor.loadThis();
-                methodVisitor.swap();
-                methodVisitor.invokeVirtual(
-                        Type.getType(propertyClass),
-                        new Method("set", "(" + RenderUtils.type(targetType) + ")V")
-                );
+
+                Type propertyType = Type.getType(propertyClass);
+                Type type = RenderUtils.type(targetType);
+
+                methodVisitor.swap(type, propertyType);
+                methodVisitor.invokeVirtual(propertyType, new Method("set", "(" + type + ")V"));
             });
         }
     }

--- a/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/Car.java
+++ b/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/Car.java
@@ -16,8 +16,10 @@
 package io.github.paullo612.mlfx.compiler.test;
 
 import javafx.beans.DefaultProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
@@ -52,6 +54,8 @@ public class Car {
     private final ObservableList<Wheel> wheels = FXCollections.observableArrayList();
 
     private final ObjectProperty<EventHandler<ActionEvent>> onDrive = new SimpleObjectProperty<>(this, "onDrive");
+
+    private final DoubleProperty engineRPM = new SimpleDoubleProperty();
 
     public String getModel() {
         return model.getValue();
@@ -101,6 +105,18 @@ public class Car {
         return onDrive;
     }
 
+    public double getEngineRPM() {
+        return engineRPM.get();
+    }
+
+    public void setEngineRPM(double value) {
+        engineRPM.set(value);
+    }
+
+    public DoubleProperty engineRPMProperty() {
+        return engineRPM;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof Car)) {
@@ -113,7 +129,8 @@ public class Car {
                 && Objects.equals(engine.get(), other.engine.get())
                 && Objects.equals(anotherEngine, other.anotherEngine)
                 && Objects.equals(bodyColors, other.bodyColors)
-                && Objects.equals(wheels, other.wheels);
+                && Objects.equals(wheels, other.wheels)
+                && engineRPM.get() == other.engineRPM.get();
     }
 
     protected String dumpFields() {
@@ -130,7 +147,8 @@ public class Car {
                 ",\n  engine = " +  engine +
                 ",\n  anotherEngine = " +  anotherEngine +
                 ",\n  bodyColors = " + bodyColors +
-                ",\n  wheels = " + wheels;
+                ",\n  wheels = " + wheels +
+                ",\n  engineRPM = " + engineRPM.get();
     }
 
     @Override

--- a/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/Engine.java
+++ b/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/Engine.java
@@ -16,6 +16,8 @@
 package io.github.paullo612.mlfx.compiler.test;
 
 import javafx.beans.DefaultProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
@@ -38,6 +40,8 @@ public class Engine {
     private final StringProperty manufacturer = new SimpleStringProperty();
 
     private final Crankshaft crankshaft = new Crankshaft();
+
+    private final DoubleProperty RPM = new SimpleDoubleProperty();
 
     public EngineType getEngineType() {
         return engineType;
@@ -63,6 +67,14 @@ public class Engine {
         return crankshaft;
     }
 
+    public double getRPM() {
+        return RPM.get();
+    }
+
+    public DoubleProperty RPMProperty() {
+        return RPM;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof Engine)) {
@@ -74,7 +86,8 @@ public class Engine {
         return Objects.equals(engineType, other.engineType)
                 && Objects.equals(engineLocation, other.engineLocation)
                 && Objects.equals(manufacturer.get(), other.manufacturer.get())
-                && crankshaft.equals(other.crankshaft);
+                && crankshaft.equals(other.crankshaft)
+                && RPM.get() == other.RPM.get();
     }
 
     @Override
@@ -84,6 +97,7 @@ public class Engine {
                 ",\n  engineLocation = " + engineLocation +
                 ",\n  manufacturer = " + manufacturer.get() +
                 ",\n  crankshaft = " + crankshaft +
+                ",\n  RPM = " + RPM.get() +
                 "\n}";
     }
 }

--- a/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive_expression/TwoSlotsPrimitiveExpression.java
+++ b/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive_expression/TwoSlotsPrimitiveExpression.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Paullo612
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.paullo612.mlfx.compiler.compliance.two_slots_primitive_expression;
+
+import io.github.paullo612.mlfx.api.CompileFXML;
+
+@CompileFXML(fxmlDirectories = "io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive_expression")
+class TwoSlotsPrimitiveExpression { }

--- a/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive_expression/twoSlotsPrimitiveExpression.fxml
+++ b/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/two_slots_primitive_expression/twoSlotsPrimitiveExpression.fxml
@@ -1,0 +1,21 @@
+<!--
+  Copyright 2023 Paullo612
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?import io.github.paullo612.mlfx.compiler.test.Car?>
+<?import io.github.paullo612.mlfx.compiler.test.Engine?>
+
+<Car engineRPM="${engine.RPM}" xmlns="http://javafx.com/javafx/19.0.0" xmlns:fx="http://javafx.com/fxml/1">
+    <Engine fx:id="engine"/>
+</Car>


### PR DESCRIPTION
Do not blindly use ASM's swap method. Pass types that need to be swapped as method arguments.

Task-number: #35