### PR TITLE
Stop smashing up source type generics when checking assignability

### DIFF
--- a/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ElementUtils.java
+++ b/compiler/compiler-core/src/main/java/io/github/paullo612/mlfx/compiler/elements/ElementUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Paullo612
+ * Copyright 2025 Paullo612
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ public final class ElementUtils {
             return false;
         }
 
-        from = smashUpGeneric(from);
         to = smashUpGeneric(to);
 
         return from.isAssignable(to) && from.getArrayDimensions() == to.getArrayDimensions();
@@ -62,8 +61,6 @@ public final class ElementUtils {
         if (from.isPrimitive() && !to.isPrimitive() || !from.isPrimitive() && to.isPrimitive()) {
             return false;
         }
-
-        from = smashUpGeneric(from);
 
         Class<?> enclosingClass = to.getEnclosingClass();
 

--- a/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/GenericHolder.java
+++ b/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/GenericHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Paullo612
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.paullo612.mlfx.compiler.test;
+
+// NB: Modelled after javafx.scene.control.TreeTableView.TreeTableViewSelectionModel
+public class GenericHolder<H> extends GenericHolderBase<Generic<H>> {
+
+    public GenericHolder() {
+        super();
+    }
+
+    @Override
+    public String toString() {
+        return "GenericHolder { reference = " + getReference() + "}";
+    }
+}

--- a/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/GenericHolderBase.java
+++ b/compiler/compiler-core/src/test/java/io/github/paullo612/mlfx/compiler/test/GenericHolderBase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Paullo612
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.paullo612.mlfx.compiler.test;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
+import java.util.Objects;
+
+public class GenericHolderBase<H> {
+
+    private final ObjectProperty<H> reference = new SimpleObjectProperty<>();
+
+    public ObjectProperty<H> referenceProperty() {
+        return reference;
+    }
+
+    public H getReference() {
+        return reference.get();
+    }
+
+    public void setReference(H value) {
+        this.reference.set(value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GenericHolderBase<?> other = (GenericHolderBase<?>) o;
+        return Objects.equals(reference.get(), other.reference.get());
+    }
+
+    @Override
+    public String toString() {
+        return "GenericHolderBase { reference = " + reference.get() + "}";
+    }
+}

--- a/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/generic_property_expression/boundGenericProperty.fxml_nc
+++ b/compiler/compiler-core/src/test/resources/io/github/paullo612/mlfx/compiler/compliance/generic_property_expression/boundGenericProperty.fxml_nc
@@ -1,0 +1,25 @@
+<!--
+  Copyright 2025 Paullo612
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?import io.github.paullo612.mlfx.compiler.test.AnotherGeneric?>
+<?import io.github.paullo612.mlfx.compiler.test.GenericHolder?>
+
+<!-- Looks broken in Micronaut 3, but compiles fine with Micronaut 4 -->
+<AnotherGeneric xmlns="http://javafx.com/javafx/19.0.0" xmlns:fx="http://javafx.com/fxml/1" fx:id="top">
+    <fx:define>
+        <GenericHolder fx:id="holder"/>
+        <fx:reference source="top" bar="${holder.reference}"/>
+    </fx:define>
+</AnotherGeneric>


### PR DESCRIPTION
This prevents TreeTableView's selection model selected item to be bound. Inferred generic placeholder is smashed up to Object, but target property may have generic type set explicitly. This fixes compilation with Micronaut 4. Micronaut 3 is unable to determine that source type is placeholder, so, this is left broken here.

Task-number: #45